### PR TITLE
Bug/#38 wrong command buggy

### DIFF
--- a/src/applicationLayer.c
+++ b/src/applicationLayer.c
@@ -45,6 +45,7 @@ Result executeCommand( Command command){
             formatedValue = malloc(sizeof(command.key) + sizeof(command.value) + (sizeof(char) * 6));
             sprintf(formatedValue, "%s:%s:%s", "GET", command.key, result.value);
         }
+        free(result.value);
         result.value = formatedValue;
         return result;
     }

--- a/src/applicationLayer.c
+++ b/src/applicationLayer.c
@@ -33,9 +33,7 @@ Result executeCommand( Command command){
         formatedValue = malloc(sizeof(command.key) + sizeof(command.value) + (sizeof(char) * 6));
         sprintf(formatedValue, "%s:%s:%s", "PUT", command.key, command.value);
         result.value = formatedValue;
-        return result;
-    }
-    if(strcmp(command.order, "GET")==0){
+    } else if(strcmp(command.order, "GET")==0){
         result = find_by_key(command.key);
         if (result.error_code == 1002) {
             formatedValue = malloc(sizeof(command.key) + sizeof("key_nonexistent") + (sizeof(char) * 6));
@@ -47,9 +45,7 @@ Result executeCommand( Command command){
         }
         free(result.value);
         result.value = formatedValue;
-        return result;
-    }
-    if(strcmp(command.order, "DEL")==0){
+    } else if(strcmp(command.order, "DEL")==0){
         result =  del(command.key);
         if (result.error_code == 1002) {
             formatedValue = malloc(sizeof(command.key) + sizeof("key_nonexistent") + (sizeof(char) * 6));
@@ -60,11 +56,10 @@ Result executeCommand( Command command){
             sprintf(formatedValue, "%s:%s:%s", "DEL", command.key, "key_deleted");
         }
         result.value = formatedValue;
-        return result;
-    }
-    else{
+    } else{
         result.error_code = 1;
-        result.value = "Command not found\n";
-        return result;
+        result.value = calloc(sizeof(char), 18);
+        strcpy(result.value, "Command not found");
     }
+    return result;
 }

--- a/src/clientSession.c
+++ b/src/clientSession.c
@@ -60,10 +60,10 @@ int handleMessage(const int socketfd, char readBuffer[]) {
     int sendResult = -1;
     char* answerToClient = NULL;
     if( result.error_code != 0) {
-        answerToClient = (char*) malloc(strlen(ERROR_PREFIX) + strlen(result.value) + 1);
+        answerToClient = (char*) malloc(strlen(ERROR_PREFIX) + strlen(result.value) + 2);
         sprintf(answerToClient, "%s%s\n", ERROR_PREFIX, result.value);
     } else {
-        answerToClient = malloc(sizeof(result.value) + 3);
+        answerToClient = malloc(strlen(result.value) + 2);
         sprintf(answerToClient, "%s\n", result.value);
     }
     if(send(socketfd, answerToClient, strlen(answerToClient) +1, 0) < 0) {

--- a/src/datenhaltung.c
+++ b/src/datenhaltung.c
@@ -47,6 +47,7 @@ Result find_by_key(char* key){
 	 free(keyPath);
 	 Result result;
      if(keyFile == NULL){
+          result.value = NULL;
           result.error_code = 1002;
           return result;
      }

--- a/src/datenhaltung.c
+++ b/src/datenhaltung.c
@@ -29,7 +29,7 @@ char *readString(FILE* fileDescriptor){
 }
 
 char *concatenate(char* string1, char* string2){
-    int stringLength = sizeof(string1) + sizeof(string2);
+    int stringLength = strlen(string1) + strlen(string2) +1;
     char *combinedString;
     combinedString = malloc(stringLength);
     strcat(combinedString, string1);


### PR DESCRIPTION
The described behavior got fixed. The problem was, that in the clientSession result.value got freed, but in an error case the result.value string was not allocated with malloc. In every case in the applicationLayer, the result.value is now NULL or malloced.

I also noticed two other problems corresponding to memory allocation. First in the clientSession there was one byte too little allocated. And secondly the datenhaltung used sizeof to determine a string length. That only works on arrays and not on pointers, so it got replaced by strlen.

Resolves #38 