### PR TITLE
bug #61 gefixt, musste nur ein free() verschieben

### DIFF
--- a/src/applicationLayer.c
+++ b/src/applicationLayer.c
@@ -170,8 +170,8 @@ Result executeCommand( Command command){
         } else {
             formatedValue = malloc(sizeof(command.key) + sizeof(command.value) + (sizeof(char) * 6));
             sprintf(formatedValue, "%s:%s:%s", "GET", command.key, result.value);
+            free(result.value);
         }
-        free(result.value);
         result.value = formatedValue;
     } else if (strcmp(command.order, "DEL") == 0) {
         result = del(command.key);


### PR DESCRIPTION
im ApplicationLayer unter GET wurde immer ein free(result.value) ausgeführt, wenn der key jedoch nicht existiert, existiert auch result.value nicht...
hab das free() verschoben, so dass es nur noch bei erfolgreichem Lesen des Keys ausgeführt wird.