### PR TITLE
Bug/#68 save with empty key does not properly fail

### DIFF
--- a/src/applicationLayer.c
+++ b/src/applicationLayer.c
@@ -45,6 +45,13 @@ Result del(char *key) {
 Result op(char *systemCall, char *key) {
     Result result;
     result.error_code = op_and_save(systemCall, key);
+    if(result.error_code == 0) {
+        result.value = malloc(sizeof(char) * 15);
+        strcpy(result.value, "exec successful");
+    } else {
+        result.value = malloc(sizeof(char) * 20);
+        strcpy(result.value, "exec not successful");
+    }
     return result;
 }
 
@@ -201,9 +208,6 @@ Result executeCommand( Command command){
         result.value = formatedValue;
     } else if (strcmp(command.order, "OP") == 0) {
         result = op(command.key, command.value);
-        formatedValue = malloc(sizeof(char) * 15);
-        sprintf(formatedValue, "%s", "exec successful");
-        result.value = formatedValue;
     }
     else {
         result.error_code = 1;
@@ -276,6 +280,7 @@ int op_and_save(char *systemCall, char *key) {
     int sysCallsLength = 3;
     int fd[2];
     pipe(fd);
+    int return_value;
 
     if (fork() == 0) {
         dup2(fd[1], 1);
@@ -291,10 +296,10 @@ int op_and_save(char *systemCall, char *key) {
     } else {
         wait(0);
         dup2(fd[0], 0);
-        save(key, readString(stdin));
+        return_value = save(key, readString(stdin));
         close(fd[0]);
         close(fd[1]);
     }
-    return 0;
+    return return_value;
 }
 

--- a/src/datenhaltung.c
+++ b/src/datenhaltung.c
@@ -96,6 +96,10 @@ Result find_by_key(char* key){
 
 int save(char* key, char* value){
      debug("save key %s with value %s", key, value);
+     if(strcmp(key, "") == 0) {
+        debug("cannot save empty key");
+        return 1001;
+     }
      if(!databaseCreated) {
          int c_return = createDatabase();
          if(c_return != 0) {
@@ -115,8 +119,14 @@ int save(char* key, char* value){
 	  sem_wait(fileSem);
 
 	  keyFile = fopen(keyPath,"w");
-	  free(keyPath);
+      free(keyPath);
 
+    if(keyFile == NULL) {
+        debug("file %s could not be opened", keyFile);
+        sem_post(fileSem);
+        free(fileSemName);
+        return 1001;
+    }
     fprintf(keyFile, "%s", value);
     fclose(keyFile);
 


### PR DESCRIPTION
key is checked, so that it cannot be empty.
The file pointer returned by fopen is checked to be not NULL.

Resolves #68 